### PR TITLE
fix: Add unique origin entity code

### DIFF
--- a/docs/4.4.1-release-notes.md
+++ b/docs/4.4.1-release-notes.md
@@ -3,4 +3,4 @@
 - Terminology changes
 
 # Fix
-
+- Fix Topology not showing data from enricher

--- a/src/ExternalSearch.Providers.Bregg/BrregExternalSearchJobData.cs
+++ b/src/ExternalSearch.Providers.Bregg/BrregExternalSearchJobData.cs
@@ -13,7 +13,6 @@ namespace CluedIn.ExternalSearch.Providers.Bregg
             CountryCodeVocabularyKey = GetValue(configuration, KeyName.CountryCodeVocabularyKey, default(string));
             WebsiteVocabularyKey = GetValue(configuration, KeyName.WebsiteVocabularyKey, default(string));
             BrregCodeVocabularyKey = GetValue(configuration, KeyName.BrregCodeVocabularyKey, default(string));
-            SkipEntityCodeCreation = GetValue(configuration, KeyName.SkipEntityCodeCreation, default(bool));
         }
 
         public IDictionary<string, object> ToDictionary()
@@ -25,7 +24,6 @@ namespace CluedIn.ExternalSearch.Providers.Bregg
                 { KeyName.CountryCodeVocabularyKey, CountryCodeVocabularyKey },
                 { KeyName.WebsiteVocabularyKey, WebsiteVocabularyKey },
                 { KeyName.BrregCodeVocabularyKey, BrregCodeVocabularyKey },
-                { KeyName.SkipEntityCodeCreation, SkipEntityCodeCreation },
             };
         }
 
@@ -34,6 +32,5 @@ namespace CluedIn.ExternalSearch.Providers.Bregg
         public string CountryCodeVocabularyKey { get; set; }
         public string WebsiteVocabularyKey { get; set; }
         public string BrregCodeVocabularyKey { get; set; }
-        public bool SkipEntityCodeCreation { get; set; }
     }
 }

--- a/src/ExternalSearch.Providers.Bregg/BrregExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.Bregg/BrregExternalSearchProvider.cs
@@ -242,7 +242,7 @@ namespace CluedIn.ExternalSearch.Providers.Bregg
             if (resultItem.Data.BrregNumber == 0)
                 return null;
 
-            var code = new EntityCode(request.EntityMetaData.OriginEntityCode.Type, "brreg", $"{query.QueryKey}{request.EntityMetaData.OriginEntityCode}".ToDeterministicGuid());
+            var code = new EntityCode(request.EntityMetaData.OriginEntityCode.Type, "brreg", resultItem.Data.BrregNumber);
             var clue = new Clue(code, context.Organization);
             PopulateMetadata(clue.Data.EntityData, resultItem, request, config);
 
@@ -328,7 +328,7 @@ namespace CluedIn.ExternalSearch.Providers.Bregg
 
         public void PopulateMetadata(IEntityMetadata metadata, IExternalSearchQueryResult<BrregOrganization> resultItem, IExternalSearchRequest request, IDictionary<string, object> config)
         {
-            var code = new EntityCode(request.EntityMetaData.OriginEntityCode.Type, "brreg", $"{request.Queries.FirstOrDefault()?.QueryKey}{request.EntityMetaData.OriginEntityCode}".ToDeterministicGuid());
+            var code = new EntityCode(request.EntityMetaData.OriginEntityCode.Type, "brreg", resultItem.Data.BrregNumber);
             var jobData = new BrregExternalSearchJobData(config);
 
             metadata.EntityType       = request.EntityMetaData.EntityType;

--- a/src/ExternalSearch.Providers.Bregg/BrregExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.Bregg/BrregExternalSearchProvider.cs
@@ -242,7 +242,8 @@ namespace CluedIn.ExternalSearch.Providers.Bregg
             if (resultItem.Data.BrregNumber == 0)
                 return null;
 
-            var clue = new Clue(request.EntityMetaData.OriginEntityCode, context.Organization);
+            var code = new EntityCode(request.EntityMetaData.OriginEntityCode.Type, "brreg", $"{query.QueryKey}{request.EntityMetaData.OriginEntityCode}".ToDeterministicGuid());
+            var clue = new Clue(code, context.Organization);
             PopulateMetadata(clue.Data.EntityData, resultItem, request, config);
 
             return new[] { clue };
@@ -325,29 +326,15 @@ namespace CluedIn.ExternalSearch.Providers.Bregg
             return metadata;
         }
 
-        private EntityCode GetOriginEntityCode(IExternalSearchQueryResult<BrregOrganization> resultItem, IExternalSearchRequest request)
-        {
-            return new EntityCode(request.EntityMetaData.EntityType, GetCodeOrigin(), resultItem.Data.BrregNumber);
-        }
-
-        private CodeOrigin GetCodeOrigin()
-        {
-            return CodeOrigin.CluedIn.CreateSpecific("brreg");
-        }
-
         public void PopulateMetadata(IEntityMetadata metadata, IExternalSearchQueryResult<BrregOrganization> resultItem, IExternalSearchRequest request, IDictionary<string, object> config)
         {
+            var code = new EntityCode(request.EntityMetaData.OriginEntityCode.Type, "brreg", $"{request.Queries.FirstOrDefault()?.QueryKey}{request.EntityMetaData.OriginEntityCode}".ToDeterministicGuid());
             var jobData = new BrregExternalSearchJobData(config);
-            var code = request.EntityMetaData.OriginEntityCode;
 
             metadata.EntityType       = request.EntityMetaData.EntityType;
             metadata.Name             = request.EntityMetaData.Name;
             metadata.OriginEntityCode = code;
-
-            if (!jobData.SkipEntityCodeCreation)
-            {
-                metadata.Codes.Add(GetOriginEntityCode(resultItem, request));
-            }
+            metadata.Codes.Add(request.EntityMetaData.OriginEntityCode);
 
             Uri uri = null;
 

--- a/src/ExternalSearch.Providers.Bregg/Constants.cs
+++ b/src/ExternalSearch.Providers.Bregg/Constants.cs
@@ -14,7 +14,6 @@ namespace CluedIn.ExternalSearch.Providers.Bregg
             public const string CountryCodeVocabularyKey = "countryCodeVocabularyKey";
             public const string WebsiteVocabularyKey = "websiteVocabularyKey";
             public const string BrregCodeVocabularyKey = "brregCodeVocabularyKey";
-            public const string SkipEntityCodeCreation = "skipEntityCodeCreation";
         }
 
         public const string ComponentName = "Brreg";
@@ -100,14 +99,6 @@ namespace CluedIn.ExternalSearch.Providers.Bregg
                     Name = KeyName.BrregCodeVocabularyKey,
                     Help = "The vocabulary key that contains the Brreg codes of companies you want to enrich (e.g., organization.brregs)."
                 },
-                new()
-                {
-                    DisplayName = $"Skip {EntityCodeLabel} Creation (Brreg Code)",
-                    Type = "checkbox",
-                    IsRequired = false,
-                    Name =  KeyName.SkipEntityCodeCreation,
-                    Help = $"Toggle to control the creation of new {EntityCodesLabel.ToLower()} using the Brreg code."
-                }
             }
         };
 


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#47706](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/47706)

Topology now showing Brreg data, but the one from other enricher turn into no source
![image](https://github.com/user-attachments/assets/744e3eff-2090-462f-ae04-09ff676c8111)

## How has it been tested? <!-- Remove if not needed -->
Manually in local
