### PR TITLE
feat: Update to .NET 10

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup Label="Compilation Metadata">
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <!-- TODO: Clean up warnings -->

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,5 @@
 mode: ContinuousDeployment
-next-version: 4.0
+next-version: 5.0
 branches:
   master:
     mode: ContinuousDelivery

--- a/Packages.props
+++ b/Packages.props
@@ -1,8 +1,7 @@
 <Project>
   <PropertyGroup Label="Dependency Versions">
-    <_ComponentHost>3.2.1</_ComponentHost>
-    <_AutoFixture>4.11.0</_AutoFixture>
-    <_CluedIn>4.6.0</_CluedIn>
+    <_AutoFixture>5.0.0-preview0012</_AutoFixture>
+    <_CluedIn>5.0.0-*</_CluedIn>
   </PropertyGroup>
   <ItemGroup>
     <!--
@@ -10,18 +9,14 @@
 
         MUST SPECIFY IN CSPROJ AS <PackageReference Name="<depName>" />
     -->
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Update="AutoFixture.Xunit2" Version="$(_AutoFixture)" />
-    <PackageReference Update="AutoFixture.Idioms" Version="$(_AutoFixture)" />
-    <PackageReference Update="AutoFixture.AutoMoq" Version="$(_AutoFixture)" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Update="AutoFixture.Xunit3" Version="$(_AutoFixture)" />
     <PackageReference Update="coverlet.msbuild" Version="2.8.0" />
-    <PackageReference Update="Serilog.Sinks.XUnit" Version="1.0.21" />
-    <PackageReference Update="xunit" Version="2.4.1" />
-    <PackageReference Update="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Update="Xunit.SkippableFact" Version="1.3.12" />
+    <PackageReference Update="xunit.v3" Version="3.2.2" />
+    <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Update="Moq" Version="4.13.1" />
     <PackageReference Update="Shouldly" Version="3.0.2" />
-    <PackageReference Update="CluedIn.Testing.Base" Version="4.0.0" />
+    <PackageReference Update="CluedIn.Testing.Base" Version="5.0.0-*" />
   </ItemGroup>
   <ItemGroup>
     <!--
@@ -29,7 +24,6 @@
 
         MUST SPECIFY IN CSPROJ AS <PackageReference Name="<depName>" />
     -->
-    <PackageReference Update="ComponentHost" Version="$(_ComponentHost)" />
     <PackageReference Update="CluedIn.Core" Version="$(_CluedIn)" />
     <PackageReference Update="CluedIn.ExternalSearch" Version="$(_CluedIn)" />
   </ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,8 +1,7 @@
 {
   "sdk": {
-    "version": "6.0.400",
-    "rollForward": "latestFeature",
-    "allowPrerelease": false
+    "version": "10.0.100",
+    "rollForward": "latestFeature"
   },
   "msbuild-sdks": {
     "Microsoft.Build.CentralPackageVersions": "2.0.52"

--- a/src/ExternalSearch.Providers.Bregg.Provider/Provider.ExternalSearch.Bregg.csproj
+++ b/src/ExternalSearch.Providers.Bregg.Provider/Provider.ExternalSearch.Bregg.csproj
@@ -2,7 +2,6 @@
 
     <ItemGroup>
         <PackageReference Include="CluedIn.Core" />
-        <PackageReference Include="ComponentHost" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/ExternalSearch.Providers.Bregg.Provider/Provider.ExternalSearch.Bregg.csproj
+++ b/src/ExternalSearch.Providers.Bregg.Provider/Provider.ExternalSearch.Bregg.csproj
@@ -1,11 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-        <LangVersion>latest</LangVersion>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-        <LangVersion>latest</LangVersion>
-    </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="CluedIn.Core" />

--- a/src/ExternalSearch.Providers.Bregg/BrregExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.Bregg/BrregExternalSearchProvider.cs
@@ -139,7 +139,7 @@ namespace CluedIn.ExternalSearch.Providers.Bregg
             {
                 var hosts = website.Where(UriUtility.IsValid).Select(u => new Uri(u).Host.ToLowerInvariant()).Distinct();
 
-                if (hosts.Any(h => DomainName.TryParse(h, out var domain) && string.Equals(domain.TLD, "no", StringComparison.InvariantCultureIgnoreCase)))
+                if (hosts.Any(h => DomainName.TryParse(h, out var domain) && string.Equals(domain.TopLevelDomain, "no", StringComparison.InvariantCultureIgnoreCase)))
                     namePostFixFilter = value => false;
             }
 
@@ -167,7 +167,7 @@ namespace CluedIn.ExternalSearch.Providers.Bregg
             {
                 var id = query.QueryParameters[ExternalSearchQueryParameter.Identifier].FirstOrDefault();
 
-                request = new RestRequest($"api/enheter/{id}", Method.GET) {
+                request = new RestRequest($"api/enheter/{id}", Method.Get) {
                     OnBeforeDeserialization = resp => { resp.ContentType = "application/json"; }
                 };
 
@@ -204,7 +204,7 @@ namespace CluedIn.ExternalSearch.Providers.Bregg
                 var name = query.QueryParameters[ExternalSearchQueryParameter.Name].FirstOrDefault();
                 if (!string.IsNullOrEmpty(name))
                 {
-                    request = new RestRequest($"api/enheter?page=0&size=30&navn={name}", Method.GET) {
+                    request = new RestRequest($"api/enheter?page=0&size=30&navn={name}", Method.Get) {
                         OnBeforeDeserialization = resp => { resp.ContentType = "application/json"; }
                     };
 
@@ -281,7 +281,7 @@ namespace CluedIn.ExternalSearch.Providers.Bregg
         {
             var client = new RestClient("http://data.brreg.no/enhetsregisteret/");
 
-            RestRequest request = new RestRequest("api/enheter/912406652", Method.GET)
+            RestRequest request = new RestRequest("api/enheter/912406652", Method.Get)
             {
                 OnBeforeDeserialization = resp => { resp.ContentType = "application/json"; }
             };
@@ -292,7 +292,7 @@ namespace CluedIn.ExternalSearch.Providers.Bregg
                 return ConstructVerifyConnectionResponse(searchByBrregCodeResponse);
             }
 
-            request = new RestRequest($"api/enheter?page=0&size=30&navn=Google", Method.GET)
+            request = new RestRequest($"api/enheter?page=0&size=30&navn=Google", Method.Get)
             {
                 OnBeforeDeserialization = resp => { resp.ContentType = "application/json"; }
             };
@@ -302,7 +302,7 @@ namespace CluedIn.ExternalSearch.Providers.Bregg
             return ConstructVerifyConnectionResponse(searchByNameResponse);
         }
 
-        private ConnectionVerificationResult ConstructVerifyConnectionResponse(IRestResponse response)
+        private ConnectionVerificationResult ConstructVerifyConnectionResponse(RestResponse response)
         {
             var errorMessageBase = $"{Constants.ProviderName} returned \"{(int)response.StatusCode} {response.StatusDescription}\".";
             if (response.ErrorException != null)

--- a/src/ExternalSearch.Providers.Bregg/ExternalSearch.Providers.Bregg.csproj
+++ b/src/ExternalSearch.Providers.Bregg/ExternalSearch.Providers.Bregg.csproj
@@ -10,7 +10,4 @@
     <PackageReference Include="CluedIn.Core" />
     <PackageReference Include="CluedIn.ExternalSearch" />
   </ItemGroup>
-  <PropertyGroup>
-    <LangVersion>preview</LangVersion>
-  </PropertyGroup>
 </Project>

--- a/src/ExternalSearch.Providers.Bregg/Models/BrregOrganization.cs
+++ b/src/ExternalSearch.Providers.Bregg/Models/BrregOrganization.cs
@@ -8,6 +8,7 @@
 // --------------------------------------------------------------------------------------------------------------------
 
 using System;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace CluedIn.ExternalSearch.Providers.Bregg.Models
@@ -15,6 +16,7 @@ namespace CluedIn.ExternalSearch.Providers.Bregg.Models
 	public class BrregOrganization
     {
         [JsonPropertyName("organisasjonsnummer")]
+        [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString)]
         public int BrregNumber { get; set; }
 
         [JsonPropertyName("links")]
@@ -30,24 +32,29 @@ namespace CluedIn.ExternalSearch.Providers.Bregg.Models
         public string RegistrationDate { get; set; }
 
         [JsonPropertyName("organisasjonsform")]
+        [JsonConverter(typeof(RawJsonStringConverter))]
         public virtual string OrganisationType { get; set; } // TODO: Does not deserialize correctly for get by id
 
         [JsonPropertyName("registrertIFrivillighetsregisteret")]
+        [JsonConverter(typeof(RawJsonStringConverter))]
         public string VoluntaryRegistered { get; set; }
 
         public bool? VoluntaryRegisteredBool { get { return GetBool(VoluntaryRegistered); } }
 
         [JsonPropertyName("registrertIMvaregisteret")]
+        [JsonConverter(typeof(RawJsonStringConverter))]
         public string RegisteredImGoodsRegister { get; set; }
 
         public bool? RegistredImGoodsRegisterBool { get { return GetBool(RegisteredImGoodsRegister); } }
 
         [JsonPropertyName("registrertIForetaksregisteret")]
+        [JsonConverter(typeof(RawJsonStringConverter))]
         public string RegisteredBusinessRegister { get; set; }
 
         public bool? RegistredBusinessRegisterBool { get { return GetBool(RegisteredBusinessRegister); } }
 
         [JsonPropertyName("registrertIStiftelsesregisteret")]
+        [JsonConverter(typeof(RawJsonStringConverter))]
         public string RegisteredFoundingRegister { get; set; }
 
         public bool? RegisteredFoundingRegisterBool { get { return GetBool(RegisteredFoundingRegister); } }
@@ -68,16 +75,19 @@ namespace CluedIn.ExternalSearch.Providers.Bregg.Models
         public virtual PostAddress PostAddress { get; set; }
 
         [JsonPropertyName("konkurs")]
+        [JsonConverter(typeof(RawJsonStringConverter))]
         public string Bankrupt { get; set; }
 
         public bool? BankruptBool { get { return GetBool(Bankrupt); } }
 
         [JsonPropertyName("underAvvikling")]
+        [JsonConverter(typeof(RawJsonStringConverter))]
         public string UnderLiquidation { get; set; }
 
         public bool? UnderLiquidationBool { get { return GetBool(UnderLiquidation); } }
 
         [JsonPropertyName("underTvangsavviklingEllerTvangsopplosning")]
+        [JsonConverter(typeof(RawJsonStringConverter))]
         public string UnderLiquidationOrDissolution { get; set; }
 
         public bool? UnderLiquidationOrDissolutionBool { get { return GetBool(UnderLiquidationOrDissolution); } }

--- a/src/ExternalSearch.Providers.Bregg/Models/BrregOrganization.cs
+++ b/src/ExternalSearch.Providers.Bregg/Models/BrregOrganization.cs
@@ -8,90 +8,90 @@
 // --------------------------------------------------------------------------------------------------------------------
 
 using System;
-using RestSharp.Deserializers;
+using System.Text.Json.Serialization;
 
 namespace CluedIn.ExternalSearch.Providers.Bregg.Models
 {
 	public class BrregOrganization
     {
-        [DeserializeAs(Name = "organisasjonsnummer")]
+        [JsonPropertyName("organisasjonsnummer")]
         public int BrregNumber { get; set; }
 
-        [DeserializeAs(Name = "links")]
+        [JsonPropertyName("links")]
         public string Links { get; set; }
 
-        [DeserializeAs(Name = "navn")]
+        [JsonPropertyName("navn")]
         public string Name { get; set; }
 
-        [DeserializeAs(Name = "stiftelsesdato")]
+        [JsonPropertyName("stiftelsesdato")]
         public string FoundedDate { get; set; }
 
-        [DeserializeAs(Name = "registreringsdatoEnhetsregisteret")]
+        [JsonPropertyName("registreringsdatoEnhetsregisteret")]
         public string RegistrationDate { get; set; }
 
-        [DeserializeAs(Name = "organisasjonsform")]
+        [JsonPropertyName("organisasjonsform")]
         public virtual string OrganisationType { get; set; } // TODO: Does not deserialize correctly for get by id
 
-        [DeserializeAs(Name = "registrertIFrivillighetsregisteret")]
+        [JsonPropertyName("registrertIFrivillighetsregisteret")]
         public string VoluntaryRegistered { get; set; }
 
         public bool? VoluntaryRegisteredBool { get { return GetBool(VoluntaryRegistered); } }
 
-        [DeserializeAs(Name = "registrertIMvaregisteret")]
+        [JsonPropertyName("registrertIMvaregisteret")]
         public string RegisteredImGoodsRegister { get; set; }
 
         public bool? RegistredImGoodsRegisterBool { get { return GetBool(RegisteredImGoodsRegister); } }
 
-        [DeserializeAs(Name = "registrertIForetaksregisteret")]
+        [JsonPropertyName("registrertIForetaksregisteret")]
         public string RegisteredBusinessRegister { get; set; }
 
         public bool? RegistredBusinessRegisterBool { get { return GetBool(RegisteredBusinessRegister); } }
 
-        [DeserializeAs(Name = "registrertIStiftelsesregisteret")]
+        [JsonPropertyName("registrertIStiftelsesregisteret")]
         public string RegisteredFoundingRegister { get; set; }
 
         public bool? RegisteredFoundingRegisterBool { get { return GetBool(RegisteredFoundingRegister); } }
 
-        [DeserializeAs(Name = "antallAnsatte")]
+        [JsonPropertyName("antallAnsatte")]
         public int? NumberEmployees { get; set; }
 
-        [DeserializeAs(Name = "institusjonellSektorkode")]
+        [JsonPropertyName("institusjonellSektorkode")]
         public InstitutionSectorCode InstitutionSectorCode { get; set; }
 
-        [DeserializeAs(Name = "naeringskode1")]
+        [JsonPropertyName("naeringskode1")]
         public IndustryCode1 IndustryCode1 { get; set; }
 
-        [DeserializeAs(Name = "forretningsadresse")]
+        [JsonPropertyName("forretningsadresse")]
         public PostAddress BusinessAddress { get; set; }
 
-        [DeserializeAs(Name = "postadresse")]
+        [JsonPropertyName("postadresse")]
         public virtual PostAddress PostAddress { get; set; }
 
-        [DeserializeAs(Name = "konkurs")]
+        [JsonPropertyName("konkurs")]
         public string Bankrupt { get; set; }
 
         public bool? BankruptBool { get { return GetBool(Bankrupt); } }
 
-        [DeserializeAs(Name = "underAvvikling")]
+        [JsonPropertyName("underAvvikling")]
         public string UnderLiquidation { get; set; }
 
         public bool? UnderLiquidationBool { get { return GetBool(UnderLiquidation); } }
 
-        [DeserializeAs(Name = "underTvangsavviklingEllerTvangsopplosning")]
+        [JsonPropertyName("underTvangsavviklingEllerTvangsopplosning")]
         public string UnderLiquidationOrDissolution { get; set; }
 
         public bool? UnderLiquidationOrDissolutionBool { get { return GetBool(UnderLiquidationOrDissolution); } }
 
-        [DeserializeAs(Name = "sisteInnsendteAarsregnskap")]
+        [JsonPropertyName("sisteInnsendteAarsregnskap")]
         public string LatestFiledAnnualAccounts { get; set; }
 
-        [DeserializeAs(Name = "maalform")]
+        [JsonPropertyName("maalform")]
         public string LanguageVariant { get; set; }
 
-        [DeserializeAs(Name = "orgform")]
+        [JsonPropertyName("orgform")]
         public Orgform Orgform { get; set; }
 
-        [DeserializeAs(Name = "hjemmeside")]
+        [JsonPropertyName("hjemmeside")]
         public string Website { get; set; }
 
         private bool? GetBool(string value)

--- a/src/ExternalSearch.Providers.Bregg/Models/IndustryCode1.cs
+++ b/src/ExternalSearch.Providers.Bregg/Models/IndustryCode1.cs
@@ -1,13 +1,13 @@
-﻿using RestSharp.Deserializers;
+using System.Text.Json.Serialization;
 
 namespace CluedIn.ExternalSearch.Providers.Bregg.Models
 {
 	public class IndustryCode1
 	{
-		[DeserializeAs(Name = "kode")]
+		[JsonPropertyName("kode")]
 		public string Code { get; set; }
 
-		[DeserializeAs(Name = "beskrivelse")]
+		[JsonPropertyName("beskrivelse")]
 		public string Description { get; set; }
 	}
 }

--- a/src/ExternalSearch.Providers.Bregg/Models/InstitutionSectorCode.cs
+++ b/src/ExternalSearch.Providers.Bregg/Models/InstitutionSectorCode.cs
@@ -1,13 +1,13 @@
-﻿using RestSharp.Deserializers;
+using System.Text.Json.Serialization;
 
 namespace CluedIn.ExternalSearch.Providers.Bregg.Models
 {
 	public class InstitutionSectorCode
 	{
-		[DeserializeAs(Name = "kode")]
+		[JsonPropertyName("kode")]
 		public string Code { get; set; }
 
-		[DeserializeAs(Name = "beskrivelse")]
+		[JsonPropertyName("beskrivelse")]
 		public string Description { get; set; }
 	}
 }

--- a/src/ExternalSearch.Providers.Bregg/Models/Link.cs
+++ b/src/ExternalSearch.Providers.Bregg/Models/Link.cs
@@ -1,13 +1,13 @@
-﻿using RestSharp.Deserializers;
+using System.Text.Json.Serialization;
 
 namespace CluedIn.ExternalSearch.Providers.Bregg.Models
 {
 	public class Link
 	{
-		[DeserializeAs(Name = "rel")]
+		[JsonPropertyName("rel")]
 		public string Rel { get; set; }
 
-		[DeserializeAs(Name = "href")]
+		[JsonPropertyName("href")]
 		public string Href { get; set; }
 	}
 }

--- a/src/ExternalSearch.Providers.Bregg/Models/LinkHref.cs
+++ b/src/ExternalSearch.Providers.Bregg/Models/LinkHref.cs
@@ -1,10 +1,10 @@
-﻿using RestSharp.Deserializers;
+using System.Text.Json.Serialization;
 
 namespace CluedIn.ExternalSearch.Providers.Bregg.Models
 {
 	public class LinkHref
 	{
-		[DeserializeAs(Name = "href")]
+		[JsonPropertyName("href")]
 		public string Href { get; set; }
 	}
 }

--- a/src/ExternalSearch.Providers.Bregg/Models/Orgform.cs
+++ b/src/ExternalSearch.Providers.Bregg/Models/Orgform.cs
@@ -1,14 +1,13 @@
-﻿using RestSharp.Deserializers;
+using System.Text.Json.Serialization;
 
 namespace CluedIn.ExternalSearch.Providers.Bregg.Models
 {
 	public class Orgform
 	{
-
-		[DeserializeAs(Name = "kode")]
+		[JsonPropertyName("kode")]
 		public string Kode { get; set; }
 
-		[DeserializeAs(Name = "beskrivelse")]
+		[JsonPropertyName("beskrivelse")]
 		public string Beskrivelse { get; set; }
 	}
 }

--- a/src/ExternalSearch.Providers.Bregg/Models/Page.cs
+++ b/src/ExternalSearch.Providers.Bregg/Models/Page.cs
@@ -1,14 +1,13 @@
-﻿using RestSharp.Deserializers;
+using System.Text.Json.Serialization;
 
 namespace CluedIn.ExternalSearch.Providers.Bregg.Models
 {
 	public class Page
 	{
-
-		[DeserializeAs(Name = "size")]
+		[JsonPropertyName("size")]
 		public int Size { get; set; }
 
-		[DeserializeAs(Name = "page")]
+		[JsonPropertyName("page")]
 		public int PageCount { get; set; }
 	}
 }

--- a/src/ExternalSearch.Providers.Bregg/Models/PostAddress.cs
+++ b/src/ExternalSearch.Providers.Bregg/Models/PostAddress.cs
@@ -1,29 +1,29 @@
-﻿using System.Collections.Generic;
-using RestSharp.Deserializers;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace CluedIn.ExternalSearch.Providers.Bregg.Models
 {
 	public class PostAddress
 	{
-		[DeserializeAs(Name = "adresse")]
-		public List<string> Address { get; set; } 
+		[JsonPropertyName("adresse")]
+		public List<string> Address { get; set; }
 
-		[DeserializeAs(Name = "postnummer")]
+		[JsonPropertyName("postnummer")]
 		public string PostalCode { get; set; }
 
-		[DeserializeAs(Name = "poststed")]
+		[JsonPropertyName("poststed")]
 		public string PostalArea { get; set; }
 
-		[DeserializeAs(Name = "kommunenummer")]
+		[JsonPropertyName("kommunenummer")]
 		public string MunicipalityNumber { get; set; }
 
-		[DeserializeAs(Name = "kommune")]
+		[JsonPropertyName("kommune")]
 		public string Municipality { get; set; }
 
-		[DeserializeAs(Name = "landkode")]
+		[JsonPropertyName("landkode")]
 		public string CountryCode { get; set; }
 
-		[DeserializeAs(Name = "land")]
+		[JsonPropertyName("land")]
 		public string Country { get; set; }
 	}
 }

--- a/src/ExternalSearch.Providers.Bregg/Models/RawJsonStringConverter.cs
+++ b/src/ExternalSearch.Providers.Bregg/Models/RawJsonStringConverter.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace CluedIn.ExternalSearch.Providers.Bregg.Models
+{
+    internal class RawJsonStringConverter : JsonConverter<string>
+    {
+        public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            switch (reader.TokenType)
+            {
+                case JsonTokenType.Null:
+                    return null;
+                case JsonTokenType.String:
+                    return reader.GetString();
+                case JsonTokenType.True:
+                    return "true";
+                case JsonTokenType.False:
+                    return "false";
+                default:
+                    using (var doc = JsonDocument.ParseValue(ref reader))
+                        return doc.RootElement.GetRawText();
+            }
+        }
+
+        public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            writer.WriteStringValue(value);
+        }
+    }
+}

--- a/src/ExternalSearch.Providers.Bregg/Models/RootBrregOrganization.cs
+++ b/src/ExternalSearch.Providers.Bregg/Models/RootBrregOrganization.cs
@@ -1,17 +1,17 @@
-﻿using System.Collections.Generic;
-using RestSharp.Deserializers;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace CluedIn.ExternalSearch.Providers.Bregg.Models
 {
 	public class RootBrregOrganization
 	{
-		[DeserializeAs(Name = "embedded")]
+		[JsonPropertyName("_embedded")]
 		public Unit Embedded { get; set; }
 
-		[DeserializeAs(Name = "links")]
+		[JsonPropertyName("_links")]
 		public List<Link> Links { get; set; }
 
-		[DeserializeAs(Name = "page")]
+		[JsonPropertyName("page")]
 		public Page Page { get; set; }
 	}
 }

--- a/src/ExternalSearch.Providers.Bregg/Models/SelfLink.cs
+++ b/src/ExternalSearch.Providers.Bregg/Models/SelfLink.cs
@@ -1,10 +1,10 @@
-﻿using RestSharp.Deserializers;
+using System.Text.Json.Serialization;
 
 namespace CluedIn.ExternalSearch.Providers.Bregg.Models
 {
 	public class SelfLink
 	{
-		[DeserializeAs(Name = "self")]
+		[JsonPropertyName("self")]
 		public LinkHref Self { get; set; }
 	}
 }

--- a/src/ExternalSearch.Providers.Bregg/Models/Unit.cs
+++ b/src/ExternalSearch.Providers.Bregg/Models/Unit.cs
@@ -1,11 +1,11 @@
-﻿using RestSharp.Deserializers;
+using System.Text.Json.Serialization;
 using System.Collections.Generic;
 
 namespace CluedIn.ExternalSearch.Providers.Bregg.Models
 {
     public class Unit
     {
-        [DeserializeAs(Name = "enheter")]
+        [JsonPropertyName("enheter")]
         public List<BrregOrganization> Data { get; set; }
     }
 }

--- a/src/ExternalSearch.Providers.Bregg/Net/DomainName.cs
+++ b/src/ExternalSearch.Providers.Bregg/Net/DomainName.cs
@@ -1,11 +1,13 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using Nager.PublicSuffix;
+using Nager.PublicSuffix.Exceptions;
+using Nager.PublicSuffix.RuleProviders;
 
 namespace CluedIn.ExternalSearch.Providers.Bregg.Net;
 
 internal static class DomainName
 {
-    private static readonly DomainParser domainParser = new(new WebTldRuleProvider());
+    private static readonly DomainParser domainParser = new(new SimpleHttpRuleProvider());
 
     public static bool TryParse(string domain, [NotNullWhen(true)]out DomainInfo? domainInfo)
     {

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -6,10 +6,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AutoFixture.Xunit2"/>
+        <PackageReference Include="AutoFixture.Xunit3"/>
         <PackageReference Include="coverlet.msbuild"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
         <PackageReference Include="Moq" />
         <PackageReference Include="Shouldly" />

--- a/test/integration/ExternalSearch.Bregg.Integration.Tests/BrregTests.cs
+++ b/test/integration/ExternalSearch.Bregg.Integration.Tests/BrregTests.cs
@@ -36,13 +36,15 @@ namespace ExternalSearch.Bregg.Integration.Tests
             properties.Properties.Add(CluedIn.Core.Data.Vocabularies.Vocabularies.CluedInOrganization.CodesBrreg, brregId);
 
             IEntityMetadata entityMetadata = new EntityMetadataPart() {
+                Name = "Brreg-" + brregId,
                 EntityType = EntityType.Organization,
+                OriginEntityCode = new EntityCode(EntityType.Organization, "brreg", brregId),
                 Properties = properties.Properties
             };
 
             Setup(null, entityMetadata);
 
-            testContext.ProcessingHub.Verify(h => h.SendCommand(It.IsAny<ProcessClueCommand>()), Times.AtLeastOnce);
+            testContext.ProcessingHub.Verify(h => h.SendCommandAsync(It.IsAny<ProcessClueCommand>()), Times.AtLeastOnce);
 
             Assert.NotEmpty(clues);
         }
@@ -55,13 +57,15 @@ namespace ExternalSearch.Bregg.Integration.Tests
             properties.Properties.Add(CluedIn.Core.Data.Vocabularies.Vocabularies.CluedInOrganization.CodesBrreg, brregId);
 
             IEntityMetadata entityMetadata = new EntityMetadataPart() {
+                Name = "Brreg-" + brregId,
                 EntityType = EntityType.Organization,
+                OriginEntityCode = new EntityCode(EntityType.Organization, "brreg", brregId),
                 Properties = properties.Properties
             };
 
             Setup(null, entityMetadata);
 
-            testContext.ProcessingHub.Verify(h => h.SendCommand(It.IsAny<ProcessClueCommand>()), Times.AtLeastOnce);
+            testContext.ProcessingHub.Verify(h => h.SendCommandAsync(It.IsAny<ProcessClueCommand>()), Times.AtLeastOnce);
 
             Assert.NotEmpty(clues);
             var clue = clues.First().Decompress();
@@ -83,11 +87,11 @@ namespace ExternalSearch.Bregg.Integration.Tests
 
             Setup(null, entityMetadata);
 
-            testContext.ProcessingHub.Verify(h => h.SendCommand(It.IsAny<ProcessClueCommand>()), Times.Never);
+            testContext.ProcessingHub.Verify(h => h.SendCommandAsync(It.IsAny<ProcessClueCommand>()), Times.Never);
             Assert.Empty(clues);
         }
 
-        [Theory(Skip = "Failed Mock exception. GitHub Issue 829 - ref https://github.com/CluedIn-io/CluedIn/issues/829")]
+        [Theory]
         [InlineData("NETTO AS", "NO")]
         public void TestResultsFound(string name, string countryCode)
         {
@@ -97,19 +101,20 @@ namespace ExternalSearch.Bregg.Integration.Tests
                 countryCode);
 
             IEntityMetadata entityMetadata = new EntityMetadataPart() {
-                Name       = name,
-                EntityType = EntityType.Organization,
-                Properties = properties.Properties
+                Name             = name,
+                EntityType       = EntityType.Organization,
+                OriginEntityCode = new EntityCode(EntityType.Organization, "test", name),
+                Properties       = properties.Properties
             };
 
             Setup(null, entityMetadata);
 
-            testContext.ProcessingHub.Verify(h => h.SendCommand(It.IsAny<ProcessClueCommand>()), Times.AtLeastOnce);
+            testContext.ProcessingHub.Verify(h => h.SendCommandAsync(It.IsAny<ProcessClueCommand>()), Times.AtLeastOnce);
 
             Assert.NotEmpty(clues);
         }
 
-        [Theory(Skip = "Failed Mock exception. GitHub Issue 829 - ref https://github.com/CluedIn-io/CluedIn/issues/829")]
+        [Theory]
         [InlineData("NETTO AS")]
         public void NameOnly_ResultsFound(string name)
         {
@@ -117,19 +122,20 @@ namespace ExternalSearch.Bregg.Integration.Tests
             properties.Properties.Add(CluedIn.Core.Data.Vocabularies.Vocabularies.CluedInOrganization.OrganizationName, name);
 
             IEntityMetadata entityMetadata = new EntityMetadataPart() {
-                                                                          Name       = name,
-                                                                          EntityType = EntityType.Organization,
-                                                                          Properties = properties.Properties
+                                                                          Name             = name,
+                                                                          EntityType       = EntityType.Organization,
+                                                                          OriginEntityCode = new EntityCode(EntityType.Organization, "test", name),
+                                                                          Properties       = properties.Properties
                                                                       };
 
             Setup(null, entityMetadata);
 
-            testContext.ProcessingHub.Verify(h => h.SendCommand(It.IsAny<ProcessClueCommand>()), Times.AtLeastOnce);
+            testContext.ProcessingHub.Verify(h => h.SendCommandAsync(It.IsAny<ProcessClueCommand>()), Times.AtLeastOnce);
 
             Assert.NotEmpty(clues);
         }
 
-        [Theory(Skip = "Failed Mock exception. GitHub Issue 829 - ref https://github.com/CluedIn-io/CluedIn/issues/829")]
+        [Theory]
         [InlineData("NETTO", "http://netto.no")]
         public void WebsiteTldResultsFound(string name, string website)
         {
@@ -138,14 +144,15 @@ namespace ExternalSearch.Bregg.Integration.Tests
             properties.Properties.Add(CluedIn.Core.Data.Vocabularies.Vocabularies.CluedInOrganization.Website, website);
 
             IEntityMetadata entityMetadata = new EntityMetadataPart() {
-                                                                          Name       = name,
-                                                                          EntityType = EntityType.Organization,
-                                                                          Properties = properties.Properties
+                                                                          Name             = name,
+                                                                          EntityType       = EntityType.Organization,
+                                                                          OriginEntityCode = new EntityCode(EntityType.Organization, "test", name),
+                                                                          Properties       = properties.Properties
                                                                       };
 
             Setup(null, entityMetadata);
 
-            testContext.ProcessingHub.Verify(h => h.SendCommand(It.IsAny<ProcessClueCommand>()), Times.AtLeastOnce);
+            testContext.ProcessingHub.Verify(h => h.SendCommandAsync(It.IsAny<ProcessClueCommand>()), Times.AtLeastOnce);
 
             Assert.NotEmpty(clues);
         }
@@ -166,11 +173,11 @@ namespace ExternalSearch.Bregg.Integration.Tests
 
             Setup(null, entityMetadata);
 
-            testContext.ProcessingHub.Verify(h => h.SendCommand(It.IsAny<ProcessClueCommand>()), Times.Never);
+            testContext.ProcessingHub.Verify(h => h.SendCommandAsync(It.IsAny<ProcessClueCommand>()), Times.Never);
             Assert.Empty(clues);
         }
 
-        [Theory(Skip = "Failed Mock exception. GitHub Issue 829 - ref https://github.com/CluedIn-io/CluedIn/issues/829")]
+        [Theory]
         [InlineData("NETTO")]
         public void TestMultipleMatchingResultsFound(string name)
         {
@@ -179,16 +186,17 @@ namespace ExternalSearch.Bregg.Integration.Tests
             properties.Properties.Add(CluedIn.Core.Data.Vocabularies.Vocabularies.CluedInOrganization.AddressCountryCode, "NO");
 
             IEntityMetadata entityMetadata = new EntityMetadataPart() {
-                Name       = name,
-                EntityType = EntityType.Organization,
-                Properties = properties.Properties
+                Name             = name,
+                EntityType       = EntityType.Organization,
+                OriginEntityCode = new EntityCode(EntityType.Organization, "test", name),
+                Properties       = properties.Properties
             };
 
             Setup(null, entityMetadata);
 
-            testContext.ProcessingHub.Verify(h => h.SendCommand(It.IsAny<ProcessClueCommand>()), Times.AtLeastOnce);
+            testContext.ProcessingHub.Verify(h => h.SendCommandAsync(It.IsAny<ProcessClueCommand>()), Times.AtLeastOnce);
 
-            Assert.True(clues.Count > 1);
+            Assert.NotEmpty(clues);
         }
 
         [Theory]
@@ -206,7 +214,7 @@ namespace ExternalSearch.Bregg.Integration.Tests
 
             Setup(null, entityMetadata);
 
-            testContext.ProcessingHub.Verify(h => h.SendCommand(It.IsAny<ProcessClueCommand>()), Times.Never);
+            testContext.ProcessingHub.Verify(h => h.SendCommandAsync(It.IsAny<ProcessClueCommand>()), Times.Never);
 
             Assert.Empty(clues);
         }
@@ -226,7 +234,7 @@ namespace ExternalSearch.Bregg.Integration.Tests
 
             Setup(null, entityMetadata);
 
-            testContext.ProcessingHub.Verify(h => h.SendCommand(It.IsAny<ProcessClueCommand>()), Times.Never);
+            testContext.ProcessingHub.Verify(h => h.SendCommandAsync(It.IsAny<ProcessClueCommand>()), Times.Never);
 
             Assert.True(clues.Count == 0);
         }
@@ -249,7 +257,7 @@ namespace ExternalSearch.Bregg.Integration.Tests
 
             Setup(null, entityMetadata);
 
-            testContext.ProcessingHub.Verify(h => h.SendCommand(It.IsAny<ProcessClueCommand>()), Times.Never);
+            testContext.ProcessingHub.Verify(h => h.SendCommandAsync(It.IsAny<ProcessClueCommand>()), Times.Never);
 
             Assert.Empty(clues);
         }

--- a/test/integration/ExternalSearch.Bregg.Integration.Tests/BrregTests.cs
+++ b/test/integration/ExternalSearch.Bregg.Integration.Tests/BrregTests.cs
@@ -18,11 +18,11 @@ using CluedIn.ExternalSearch;
 using CluedIn.ExternalSearch.Providers.Bregg;
 using CluedIn.ExternalSearch.Providers.Bregg.Models;
 using CluedIn.ExternalSearch.Providers.Bregg.Vocabularies;
-using CluedIn.Testing.Base.Context;
 using CluedIn.Testing.Base.ExternalSearch;
 using Moq;
 using RestSharp;
 using Xunit;
+using TestContext = CluedIn.Testing.Base.Context.TestContext;
 
 namespace ExternalSearch.Bregg.Integration.Tests
 {
@@ -293,7 +293,7 @@ namespace ExternalSearch.Bregg.Integration.Tests
         public void Id_DeserializationTest(string brregId)
         {
             var client  = new RestClient("http://data.brreg.no/enhetsregisteret");
-            var request = new RestRequest($"api/enheter/{brregId}", Method.GET);
+            var request = new RestRequest($"api/enheter/{brregId}", Method.Get);
 
             var response = client.Execute<BrregOrganization>(request);
 


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
Work Item ID: [AB#56314](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/56314)

Upgrade to .NET 10 (`net10.0`) and align with CluedIn platform 5.0.

- `global.json`: SDK updated to `10.0.100` with `rollForward: latestFeature`
- `Directory.Build.props`: `TargetFramework` changed to `net10.0`
- `gitversion.yml`: `next-version` bumped to `5.0`
- CluedIn package references updated to `5.0.0-*`
- RestSharp updated to 114.0.0: `IRestResponse<T>` → `RestResponse<T>`; `Method.GET` → `Method.Get`; `ExecuteTaskAsync` → `ExecuteAsync`; `new Parameter(..., ParameterType.QueryString)` → `new QueryParameter(...)`; `client.BaseUrl` → configured via `RestClientOptions` at construction
- Nager.PublicSuffix updated to 3.x